### PR TITLE
Hide inactive sites on manageMySites by default

### DIFF
--- a/data/sql-updates/feature-inactive-old-sites.sql
+++ b/data/sql-updates/feature-inactive-old-sites.sql
@@ -1,0 +1,5 @@
+UPDATE Site
+  LEFT JOIN (select distinct SiteFK from Survey JOIN Plant ON Plant.ID = Survey.PlantFK WHERE Survey.LocalDate > '2023-01-01') AS Survey
+  ON Site.ID = Survey.SiteFK
+  SET Site.Active = 0
+  WHERE Survey.SiteFK IS NULL AND Site.DateEstablished < '2024-01-01';

--- a/manageMySites/index.html
+++ b/manageMySites/index.html
@@ -115,6 +115,10 @@
 				overflow:hidden;
 			}
 
+                        .select .option.hidden {
+                                display:none;
+                        }
+                 
 			.select .option.selected{
 				max-height:250px;
 				overflow:hidden;
@@ -464,25 +468,45 @@
 				xhttp.onreadystatechange = function() {
 					if (this.readyState == 4 && this.status == 200) {
 						if(this.responseText.indexOf("true") == 0){
-							var ownedSites = JSON.parse(this.responseText.replace("true|", ""));
+						    var ownedSites = JSON.parse(this.responseText.replace("true|", ""));
+                                                    ownedSites.forEach(site => {
+                                                        site.nameAndRegion = site["name"] + " (" + site["region"] + ")";
+                                                    })
+						    ownedSites.sort(function(a, b){
+                                                        return a.nameAndRegion.localeCompare(b.nameAndRegion);
+						    });
+						    
+						    var onlyOwnsOneSite = (ownedSites.length == 1);
+						    
+						    var htmlToAdd = "<div class=\"select\">";
+						    htmlToAdd += "<div class=\"option" + (onlyOwnsOneSite ? "" : " selected") + "\" onclick=\"selectOption(this);\">	<div class=\"value\"></div>			<div class=\"shown\"><div class=\"image\" style=\"background-image:url('../images/selectIcons/notselected.png');\"></div>		<div class=\"text\">Site not selected</div></div></div>";
+                                                    function siteHTML(site, extraCls) {
+                                                        return "<div class=\"option" + (onlyOwnsOneSite ? " selected" : "") + " " + extraCls + "\" onclick=\"selectOption(this);\">	<div class=\"value\">" + site["id"] + "</div>			<div class=\"shown\"><div class=\"image\"></div>		<div class=\"text\">" + site.nameAndRegion + "</div></div></div>";
+                                                    }
+                                                    
+                                                    let activeSites = ownedSites.filter(a => a.active);
+                                                    let inactiveSites = ownedSites.filter(a => !a.active);
 
-							ownedSites.sort(function(a, b){
-								if((a["name"] + " (" + a["region"] + ")").toLowerCase() < (b["name"] + " (" + b["region"] + ")").toLowerCase()){return -1;}
-								if((a["name"] + " (" + a["region"] + ")").toLowerCase() > (b["name"] + " (" + b["region"] + ")").toLowerCase()){return 1;}
-								return 0;
-							});
-							
-							var onlyOwnsOneSite = (ownedSites.length == 1);
-							
-							var htmlToAdd = "<div class=\"select\">";
-							htmlToAdd += "<div class=\"option" + (onlyOwnsOneSite ? "" : " selected") + "\" onclick=\"selectOption(this);\">	<div class=\"value\"></div>			<div class=\"shown\"><div class=\"image\" style=\"background-image:url('../images/selectIcons/notselected.png');\"></div>		<div class=\"text\">Site not selected</div></div></div>";
-							for(var i = 0; i < ownedSites.length; i++){
-								htmlToAdd += "<div class=\"option" + (onlyOwnsOneSite ? " selected" : "") + "\" onclick=\"selectOption(this);\">	<div class=\"value\">" + ownedSites[i]["id"] + "</div>			<div class=\"shown\"><div class=\"image\"></div>		<div class=\"text\">" + ownedSites[i]["name"] + " (" + ownedSites[i]["region"] + ")</div></div></div>";
-								//htmlToAdd += "<option value=\"" + ownedSites[i]["id"] + "\">" + ownedSites[i]["name"] + " (" + ownedSites[i]["region"] + ")</option>";
-							}
-							htmlToAdd += "<div class=\"option\" onclick=\"window.location = '../createNewSite';\"><div class=\"shown\"><div class=\"image\" style=\"background-image:url('../images/plus.png');\"></div>		<div class=\"text italic\">CREATE NEW SITE</div></div></div>";
-							htmlToAdd += "</div>";
-							$("#sites")[0].innerHTML = htmlToAdd;
+                                                    if (activeSites.length < 1 && inactiveSites.length > 0) {
+                                                        activeSites = inactiveSites;
+                                                        inactiveSites = [];
+                                                    }
+                                                    
+						    for(let site of activeSites){
+							htmlToAdd += siteHTML(site);
+						    }
+
+                                                    if (inactiveSites.length > 0) {
+                                                        htmlToAdd += "<div class=\"option\" onclick=\"showInactive(this);\"><div class=\"value\"></div><div class=\"shown\"><div class=\"text italic\">SHOW INACTIVE SITES</div></div></div>";
+						        for(let site of inactiveSites){
+							    htmlToAdd += siteHTML(site, "hidden");
+						        }
+                                                        
+                                                    }
+                                                    
+						    htmlToAdd += "<div class=\"option\" onclick=\"window.location = '../createNewSite';\"><div class=\"shown\"><div class=\"image\" style=\"background-image:url('../images/plus.png');\"></div>		<div class=\"text italic\">CREATE NEW SITE</div></div></div>";
+						    htmlToAdd += "</div>";
+						    $("#sites")[0].innerHTML = htmlToAdd;
 						}
 						else{
 							var getSitesError = this.responseText.replace("false|", "");
@@ -496,6 +520,11 @@
 				xhttp.open("GET", "../php/getOwnedSitesLIGHT.php?email=" + encodeURIComponent(window.localStorage.getItem("email")) + "&salt=" + window.localStorage.getItem("salt"), true);
 				xhttp.send();
 			}
+
+                        function showInactive(el) {
+                            el.remove()
+                            document.querySelectorAll(".option.hidden").forEach(a => { a.classList.remove('hidden')})
+                        }
 
 			function printTags(){
 				var id = getSelectValue($(".select").eq(0));

--- a/php/getOwnedSitesLIGHT.php
+++ b/php/getOwnedSitesLIGHT.php
@@ -15,6 +15,7 @@
 				"id" => $sites[$i]->getID(),
 				"name" => $sites[$i]->getName(),
 				"region" => $sites[$i]->getRegion(),
+                                "active" => $sites[$i]->getActive(),
 			);
 		}
 		die("true|" . json_encode($sitesArray));


### PR DESCRIPTION
and set inactive in db for sites with no surveys since 2022 if established before 2024.

![show_inactive_sites](https://github.com/user-attachments/assets/c3b1ab77-0f8b-4c38-b170-701c81603bba)


Setting inactive also hides these sites from the "Find An Existing Site" list at `/publicSites/`, editable at Edit Site or by submitting a survey.