### PR TITLE
App editSurveyPlants needs previous versioning

### DIFF
--- a/editSurveyPlants/index.html
+++ b/editSurveyPlants/index.html
@@ -436,7 +436,7 @@
 			            }
 			        }
 			    };
-			    xhttp.open("GET", "../php/getPlantsBySite.php?siteID=" + siteID + "&email=" + encodeURIComponent(window.localStorage.getItem("email")) + "&salt=" + window.localStorage.getItem("salt") + "&appVersion=1.5.0", true);
+			    xhttp.open("GET", "../php/getPlantsBySite.php?siteID=" + siteID + "&email=" + encodeURIComponent(window.localStorage.getItem("email")) + "&salt=" + window.localStorage.getItem("salt") + "&appVersion=1.6.0", true);
 			    xhttp.send();
 			}
 

--- a/mapsAndGraphs/index.html
+++ b/mapsAndGraphs/index.html
@@ -1391,7 +1391,7 @@
                      $("#noPlantsSection").hide();
                      $("#hasPlantsSection").hide();
                      
-                     let response = await fetch("../php/getPlantsBySite.php?siteID=" + encodeURIComponent(siteID) + "&email=" + encodeURIComponent(window.localStorage.getItem("email")) + "&salt=" + window.localStorage.getItem("salt") + "&appVersion=1.5.0")
+                     let response = await fetch("../php/getPlantsBySite.php?siteID=" + encodeURIComponent(siteID) + "&email=" + encodeURIComponent(window.localStorage.getItem("email")) + "&salt=" + window.localStorage.getItem("salt") + "&appVersion=1.6.0")
                      var data = JSON.parse((await response.text()).replace("true|", ""));
 		     var siteName = data[0];
 		     var circles = data[1];

--- a/php/getPlantsBySite.php
+++ b/php/getPlantsBySite.php
@@ -26,6 +26,10 @@
 		      if($appVersion < 150){
 			      $circles[($plants[$i]->getCircle() - 1)][1][] = array($plants[$i]->getOrientation(), $plants[$i]->getCode(), $plants[$i]->getSpecies());
 		      }
+                      else if ($appVersion < 160) {
+                              $circles[($plants[$i]->getCircle() - 1)][1][] = array($plants[$i]->getOrientation(), $plants[$i]->getCode(), $plants[$i]->getSpecies(), $plants[$i]->getIsConifer());
+                      
+                      }
 		      else{
 			      $circles[($plants[$i]->getCircle() - 1)][1][] = array($plants[$i]->getOrientation(), $plants[$i]->getCode(), $plants[$i]->getSpecies(), $plants[$i]->getIsConifer(), $plants[$i]->getLatitude(), $plants[$i]->getLongitude(), $plants[$i]->getColor());
 		      }


### PR DESCRIPTION
The app implementation of editSurveyPlants was stricter about the size of API returned array of plant data than I realized, so this bumps the version number for web responses and restores the pre-plant-location response for current app versions.