### PR TITLE
Skip Expert Identifications if less than 2 were sufficiently specific

### DIFF
--- a/php/grabIdentificationsFromINaturalist.php
+++ b/php/grabIdentificationsFromINaturalist.php
@@ -135,11 +135,13 @@
 		$mostRecentCaterpillarsCountIdentification = "";
 		$mostRecentCaterpillarsCountIdentificationTimestamp = -1;
 		$numberOfCaterpillarsCountIdentifications = 0;
+                $numberOfSufficientIdentifications = count($identifications);
 		for($j = 0; $j < count($identifications); $j++){
-			$order = "";
+			$order = ""; 
 			$suborder = "";
 			$family = "";
 			if(!array_key_exists("taxon", $identifications[$j]) || $identifications[$j]["taxon"] === null || !array_key_exists("rank", $identifications[$j]["taxon"]) || $identifications[$j]["taxon"]["rank"] === null || !array_key_exists("name", $identifications[$j]["taxon"]) || $identifications[$j]["taxon"]["name"] === null){
+                                $numberOfSufficientIdentifications--;
 				continue;
 			}
 			$finestRank = $identifications[$j]["taxon"]["rank"];
@@ -214,6 +216,9 @@
 				$vote = "truebugs";
 			}
 			else{
+                                if ($order == "") {
+                                  $numberOfSufficientIdentifications--;
+                                }
 				$vote = $order;
 			}
 			
@@ -236,7 +241,11 @@
 				$identificationVotes[] = $vote;
 			}
 		}
-		
+
+                if($numberOfSufficientIdentifications < 2) {
+                        continue;//still don't allow single-vote winners
+                }
+                
 		$identificationVoteCounts = array_count_values($identificationVotes);
 		arsort($identificationVoteCounts);
 		$keys = array_keys($identificationVoteCounts);


### PR DESCRIPTION
We check for < 2 identifications earlier, but can also have the case of 2+ IDs that are e.g. "Arthropoda" and shouldn't trigger expert ID updates. So subtract any identifications that don't produce a group or order by our logic.